### PR TITLE
v0.1.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Live reloading inspired by https://github.com/air-verse/air/tree/master build wi
 ## Features
 
 - Live reloading for any programing languages
+- Live reloading for binary
 - Better building process
 - Allow watching new directories
 - Colorful log output
@@ -49,6 +50,18 @@ vim main.go
 # and run the project with rustywatch
 # then the project will be running with hot reload.
 rustywatch -d . -c 'go run main.go' --ignore .git
+```
+
+- Example using with Go (Fiber)
+
+```shell
+mkdir go-fiber;
+cd go-fiber;
+go mod init go-fiber;
+# install fiber framework
+go get github.com/gofiber/fiber/v2
+# start live reload with rustywatch
+rustywatch -d . -c 'go build main.go' --bin-path 'main'
 ```
 
 - Example using with NodeJS

--- a/src/args.rs
+++ b/src/args.rs
@@ -28,6 +28,9 @@ pub struct Args {
 
     #[arg(short = 'i', long)]
     pub ignore: Vec<String>,
+
+    #[arg(long)]
+    pub bin_path: Option<String>,
 }
 
 #[cfg(test)]
@@ -40,9 +43,16 @@ mod tests {
             dir: String::from("/test/dir"),
             command: String::from("test_command"),
             ignore: vec![String::from(".git")],
+            bin_path: None,
         };
+
         assert_eq!(args.dir, "/test/dir");
         assert_eq!(args.command, "test_command");
-        assert_eq!(args.ignore[0], ".git")
+        assert_eq!(args.ignore[0], ".git");
+
+        match args.bin_path {
+            Some(cmd_bin) => assert_eq!(cmd_bin, ""),
+            None => assert_eq!(args.bin_path.is_none(), true),
+        };
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ use log::error;
 use std::error::Error;
 
 pub async fn run(args: Args) -> Result<(), Box<dyn Error>> {
-    if let Err(err) = watch::watch_dir(args.dir, args.command, args.ignore).await {
+    if let Err(err) = watch::watch_dir(args).await {
         error!("Error watching directory: {:?}", err)
     }
 

--- a/src/watch/mod.rs
+++ b/src/watch/mod.rs
@@ -164,10 +164,7 @@ fn remove_old_binary(binary_path: &str) -> bool {
 }
 
 fn binary_exists(binary_path: &str) -> bool {
-    match metadata(binary_path) {
-        Ok(_) => true,
-        Err(_) => false,
-    }
+    metadata(binary_path).is_ok()
 }
 
 fn restart_binary(binary_path: &str) -> Child {

--- a/src/watch/mod.rs
+++ b/src/watch/mod.rs
@@ -1,48 +1,58 @@
-use log::{error, info};
+use crate::args::Args;
+use log::{error, info, warn};
 use notify::{recommended_watcher, Event, EventKind, RecursiveMode, Watcher};
 use std::{
     fs::metadata,
     io::{BufRead, BufReader},
     path::Path,
-    process::{Child, Stdio},
+    process::{self, Child, Stdio},
     result::Result,
     sync::mpsc::channel,
     time::Duration,
 };
 
-pub async fn watch_dir<P: AsRef<Path>>(
-    path: P,
-    command: String,
-    ignored_patterns: Vec<String>,
-) -> notify::Result<()> {
+pub async fn watch_dir(args: Args) -> notify::Result<()> {
     let (tx, rx) = channel();
 
     let mut watcher = recommended_watcher(move |res: Result<Event, notify::Error>| {
         tx.send(res).unwrap();
-    })?;
+    })
+    .unwrap();
 
-    watcher.watch(path.as_ref(), RecursiveMode::Recursive)?;
+    watcher
+        .watch(args.dir.as_ref(), RecursiveMode::Recursive)
+        .unwrap();
 
-    info!("Waching directory: {:?}", path.as_ref());
+    info!("Waching directory: {:?}", args.dir);
+
+    let mut running_binary: Option<Child> = None;
 
     loop {
         match rx.recv_timeout(Duration::from_secs(5)) {
             Ok(Ok(event)) => {
-                let filtered_paths: Vec<_> = event
-                    .paths
-                    .into_iter()
-                    .filter(|path| !is_ignored(path, &ignored_patterns))
-                    .collect();
+                if let EventKind::Modify(modify_kind) = event.kind {
+                    if matches!(modify_kind, notify::event::ModifyKind::Data(_)) {
+                        let paths = event
+                            .paths
+                            .iter()
+                            .filter(|path| !is_ignored(path, &args.ignore))
+                            .collect::<Vec<_>>();
 
-                if !filtered_paths.is_empty() {
-                    if let EventKind::Modify(modify_kind) = event.kind {
-                        if matches!(modify_kind, notify::event::ModifyKind::Data(_)) {
-                            for path in filtered_paths {
-                                if let Ok(metadata) = metadata(&path) {
-                                    if metadata.is_file() {
-                                        match run_command(command.clone()).await {
+                        if !paths.is_empty() {
+                            info!("File content changed: {:?}", paths);
+
+                            if let Some(ref mut child) = running_binary {
+                                match child.kill() {
+                                    Ok(_) => info!("Killed the running binary"),
+                                    Err(e) => error!("Failed to kill binary: {:?}", e),
+                                }
+                            }
+
+                            if let Some(bin_path) = &args.bin_path {
+                                if remove_old_binary(bin_path) {
+                                    if !binary_exists(bin_path) {
+                                        match run_command(args.command.clone()).await {
                                             Ok(child) => {
-                                                info!("File changed: {:?}", path);
                                                 let stdout = child.stdout.unwrap();
                                                 let stderr = child.stderr.unwrap();
                                                 let stdout_reader = BufReader::new(stdout);
@@ -60,6 +70,28 @@ pub async fn watch_dir<P: AsRef<Path>>(
                                                 error!("Failed to run command: {}", e)
                                             }
                                         }
+                                    }
+
+                                    running_binary = Some(restart_binary(bin_path));
+                                }
+                            } else {
+                                match run_command(args.command.clone()).await {
+                                    Ok(child) => {
+                                        let stdout = child.stdout.unwrap();
+                                        let stderr = child.stderr.unwrap();
+                                        let stdout_reader = BufReader::new(stdout);
+                                        let stderr_reader = BufReader::new(stderr);
+
+                                        for line in stdout_reader.lines() {
+                                            println!("{}", line.unwrap());
+                                        }
+
+                                        for line in stderr_reader.lines() {
+                                            eprintln!("{}", line.unwrap());
+                                        }
+                                    }
+                                    Err(e) => {
+                                        error!("Failed to run command: {}", e)
                                     }
                                 }
                             }
@@ -107,4 +139,47 @@ fn is_ignored<P: AsRef<Path>>(path: P, ignored_patterns: &[String]) -> bool {
     }
 
     false
+}
+
+fn remove_old_binary(binary_path: &str) -> bool {
+    match metadata(binary_path) {
+        Ok(_) => {
+            warn!("Remove old binary: {}", binary_path);
+            match std::fs::remove_file(binary_path) {
+                Ok(_) => {
+                    warn!("Old binary removed");
+                    true
+                }
+                Err(e) => {
+                    error!("Failed to remove binary: {:?}", e);
+                    false
+                }
+            }
+        }
+        Err(_) => {
+            info!("No binary found to remove.");
+            true
+        }
+    }
+}
+
+fn binary_exists(binary_path: &str) -> bool {
+    match metadata(binary_path) {
+        Ok(_) => true,
+        Err(_) => false,
+    }
+}
+
+fn restart_binary(binary_path: &str) -> Child {
+    info!("Restarting binary: {}", binary_path);
+    match std::process::Command::new(binary_path).spawn() {
+        Ok(child) => {
+            info!("Binary started: {}", child.id());
+            child
+        }
+        Err(e) => {
+            error!("Failed to restart: {:?}", e);
+            process::exit(1)
+        }
+    }
 }


### PR DESCRIPTION
**v0.1.5**

- Add feature live reloading to execute binary.
- Fix issues to running `go fiber` app .

**How to use?**

```shell
rustywatch --dir <dir> --cmd 'go build main.go' --bin-path 'main'
```