### PR TITLE
fix: improve bin_path resolution to be relative to workspace directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,23 @@ brew tap ak9024/rustywatch
 brew install rustywatch
 ```
 
-## Usage
+## Quick Start
+
+### Initialize Configuration
+
+Generate a configuration file interactively:
+
+```shell
+rustywatch init
+```
+
+Or use auto-detected defaults:
+
+```shell
+rustywatch init --yes
+```
+
+### Run RustyWatch
 
 To start the project, ensure you have a `rustywatch.yaml` configuration file in the root directory of your project. Then, run the CLI from the root directory to launch RustyWatch.
 
@@ -59,7 +75,7 @@ workspaces:
   # first project binary apps
   - dir: 'golang-project' # define path directory
     cmd: 'go build main.go' # runs in golang-project/
-    bin_path: './golang-project/main' # define path for binary location
+    bin_path: './main' # relative to workspace dir (golang-project/)
     bin_arg: # define arguments
      - server
     ignore:
@@ -68,7 +84,7 @@ workspaces:
   # second project binary apps
   - dir: 'rust-project'
     cmd: 'cargo build' # runs in rust-project/
-    bin_path: './rust-project/target/debug/rust-project'
+    bin_path: './target/debug/rust-project' # relative to workspace dir
     env_file: '/.env' # load environment variables from project root .env
   # third project non binary apps
   - dir: 'nodejs-project'
@@ -102,6 +118,34 @@ ls
 ```shell
 rustywatch
 ```
+
+## Commands
+
+### Init Command
+
+Generate a configuration file interactively:
+
+```shell
+rustywatch init [OPTIONS]
+```
+
+| Option | Description |
+|--------|-------------|
+| `-o, --output <FILE>` | Config file path (default: rustywatch.yaml) |
+| `--yes` | Skip prompts, use auto-detected defaults |
+| `-f, --force` | Overwrite existing config file |
+
+Auto-detects project type: Rust, Go, Node.js, Python, Bun.
+
+### Process Monitor
+
+Launch with the built-in TUI dashboard for real-time monitoring:
+
+```shell
+rustywatch --monitor
+```
+
+Features: CPU/memory tracking, process management, system metrics.
 
 ## Help
 

--- a/rustywatch.yaml
+++ b/rustywatch.yaml
@@ -5,7 +5,7 @@ workspaces:
   cmd:
     - echo "go-fiber"
     - go build
-  bin_path: 'examples/go-fiber/go-fiber'
+  bin_path: 'go-fiber'
 - dir: 'examples/nodejs'
   cmd:
     - echo "nodejs"
@@ -14,7 +14,7 @@ workspaces:
   cmd:
     - echo "rust-actix"
     - cargo build
-  bin_path: 'examples/rust-actix/target/debug/rust-actix'
+  bin_path: 'target/debug/rust-actix'
   ignore:
     - 'examples/rust-actix/target/'
 - dir: 'examples/bun'

--- a/src/watch/notify.rs
+++ b/src/watch/notify.rs
@@ -72,7 +72,7 @@ pub async fn watcher(
     // Listen to the directory with recursive mode
     match watcher.watch(dir.as_ref(), RecursiveMode::Recursive) {
         Ok(_) => {
-            info!("Waching directory: {:?}", dir);
+            info!("Watching directory: {:?}", dir);
 
             // In testing env, skip the loop to prevent blocking
             if cfg!(test) {

--- a/src/watch/reload.rs
+++ b/src/watch/reload.rs
@@ -69,13 +69,24 @@ pub async fn reload(
 
     match bin_path {
         Some(bin_path) => {
-            // Convert bin_path to absolute path so it works regardless of current_dir
+            // Convert bin_path to truly absolute path
             let absolute_bin_path = if Path::new(bin_path).is_absolute() {
                 bin_path.to_string()
             } else {
+                // Join CWD + work_dir + bin_path for consistent path resolution
                 env::current_dir()
-                    .map(|cwd| cwd.join(bin_path).to_string_lossy().to_string())
-                    .unwrap_or_else(|_| bin_path.to_string())
+                    .map(|cwd| {
+                        cwd.join(work_dir)
+                            .join(bin_path)
+                            .to_string_lossy()
+                            .to_string()
+                    })
+                    .unwrap_or_else(|_| {
+                        Path::new(work_dir)
+                            .join(bin_path)
+                            .to_string_lossy()
+                            .to_string()
+                    })
             };
 
             if remove(&absolute_bin_path) {
@@ -88,12 +99,18 @@ pub async fn reload(
                     return;
                 }
 
+                // Skip restart if binary doesn't exist after build
+                if !exists(&absolute_bin_path) {
+                    *running_binary = None;
+                    return;
+                }
+
                 // Restart the binary using absolute path
                 match restart(&absolute_bin_path, bin_arg, env_vars, work_dir) {
                     Ok(child) => *running_binary = Some(child),
                     Err(e) => {
                         error!("Failed to restart binary: {:?}", e.to_string());
-                        error!("Please check your <bin_path>: {}", bin_path);
+                        error!("Please check your <bin_path>: {}", absolute_bin_path);
                         *running_binary = None
                     }
                 }

--- a/web/src/content/docs/blog/v0.3.0.md
+++ b/web/src/content/docs/blog/v0.3.0.md
@@ -4,7 +4,58 @@ sidebar:
   order: 2
 ---
 
-Plan for v0.3.0
+## What's New in v0.3.0
 
-- Add commands `init` to initialize configuration automatically.
-- TBD please add request in https://github.com/ak9024/rustywatch/issues
+### Init Command
+
+Generate configuration files interactively with `rustywatch init`:
+
+```shell
+rustywatch init        # Interactive mode
+rustywatch init --yes  # Use auto-detected defaults
+```
+
+Features:
+- Auto-detects project type (Rust, Go, Node.js, Python, Bun)
+- Interactive prompts for configuration
+- Preview before writing
+
+### Environment Variables
+
+Load environment variables from `.env` files per workspace:
+
+```yaml
+workspaces:
+  - dir: 'my-app'
+    cmd: 'npm start'
+    env_file: '.env'        # relative to workspace dir
+    # env_file: '/.env'     # from project root
+```
+
+### Auto Working Directory
+
+Commands now execute in the workspace directory automatically. No need for `cd` prefixes:
+
+```yaml
+workspaces:
+  - dir: 'my-app'
+    cmd: 'npm run build'  # runs in my-app/
+```
+
+### Improved Path Resolution
+
+`bin_path` is now relative to the workspace directory:
+
+```yaml
+# Before (redundant paths)
+- dir: 'examples/rust-app'
+  bin_path: 'examples/rust-app/target/debug/rust-app'
+
+# After (cleaner)
+- dir: 'examples/rust-app'
+  bin_path: './target/debug/rust-app'
+```
+
+---
+
+Have suggestions? [Open an issue](https://github.com/ak9024/rustywatch/issues)

--- a/web/src/content/docs/getting-started/index.md
+++ b/web/src/content/docs/getting-started/index.md
@@ -16,10 +16,31 @@ title: Getting Started
 
 **Installation**
 
-> Open your terminal and run:
+> Using Cargo:
 
 ```shell
 cargo install rustywatch
+```
+
+> Or using Homebrew:
+
+```shell
+brew tap ak9024/rustywatch
+brew install rustywatch
+```
+
+**Quick Start with Init**
+
+Generate a configuration file automatically:
+
+```shell
+rustywatch init
+```
+
+Or use auto-detected defaults:
+
+```shell
+rustywatch init --yes
 ```
 
 **Configuration**
@@ -32,8 +53,8 @@ workspaces:
   - dir: go-project
     # commands run automatically in 'go-project/' directory
     cmd: go build
-    # add your binary location
-    bin_path: 'go-project/go-project'
+    # binary path relative to workspace dir
+    bin_path: './go-project'
     # optional: if do you have a specific arguments
     bin_arg:
       - server # go run main.go server
@@ -46,7 +67,7 @@ workspaces:
   # Add another projects
   - dir: <your_dir>
     cmd: <your_commands>
-    bin_path: <your_bin_location>
+    bin_path: <your_bin_location>  # relative to workspace dir
     bin_arg: <your_bin_arguments>
     ignore: <ignore>
     env_file: <path_to_env_file>

--- a/web/src/content/docs/index.mdx
+++ b/web/src/content/docs/index.mdx
@@ -3,10 +3,10 @@ title: Welcome to RustyWatch
 head:
   - tag: title
     content: RustyWatch - Hot Reloader for your App's
-description: Live Reloading for any programing languages
+description: Live Reloading for any programming languages
 template: splash
 hero:
-  tagline: Live Reloading for any programing languages
+  tagline: Live Reloading for any programming languages
   actions:
     - text: Try it!
       link: /getting-started

--- a/web/src/content/docs/installation/cargo.md
+++ b/web/src/content/docs/installation/cargo.md
@@ -1,8 +1,10 @@
 ---
-title: Cargo
+title: Cargo & Homebrew
 sidebar:
   order: 1
 ---
+
+## Using Cargo
 
 :::note
 
@@ -10,15 +12,32 @@ sidebar:
 
 :::
 
-**Install**
+**Install from crates.io**
 
 ```shell
 cargo install rustywatch
 ```
+
 **Install directly from git**
 
 ```shell
 cargo install --git https://github.com/ak9024/rustywatch
+```
+
+## Using Homebrew
+
+:::note
+
+Available for macOS and Linux.
+
+:::
+
+```shell
+# Add the tap
+brew tap ak9024/rustywatch
+
+# Install rustywatch
+brew install rustywatch
 ```
 
 

--- a/web/src/content/docs/reference/reference.md
+++ b/web/src/content/docs/reference/reference.md
@@ -9,6 +9,8 @@ description: A reference page
 rustywatch -h
 ```
 
+### Watch Options
+
 | **Option**   | **Description**                                                | **Type**    |
 |--------------|----------------------------------------------------------------|-------------|
 | `--dir`      | Specifies the configuration directory to be monitored by RustyWatch. | `string`    |
@@ -16,7 +18,19 @@ rustywatch -h
 | `--bin_path` | Specifies the path to the binary to execute, invoked after `--cmd`. | `string`    |
 | `--bin_arg`  | Allows you to provide additional arguments for the binary.     | `array`     |
 | `--ignore`   | Lists directories or files to be ignored.                      | `array`     |
-| `--cmd`      | Custom command to be executed.                                 | `array`    |
+| `--monitor`  | Launch with the TUI dashboard for real-time process monitoring. | `flag`     |
+
+### Init Command
+
+```shell
+rustywatch init [OPTIONS]
+```
+
+| **Option**   | **Description**                                                | **Type**    |
+|--------------|----------------------------------------------------------------|-------------|
+| `-o, --output` | Config file path (default: `rustywatch.yaml`)                | `string`    |
+| `--yes`      | Skip prompts and use auto-detected defaults                    | `flag`      |
+| `-f, --force`| Overwrite existing config file                                 | `flag`      |
 
 ##### Workspaces
 
@@ -39,8 +53,8 @@ All field under `workspaces` are using `array`:
 |---------------|------------------------------------------------------------------|----------------------|
 | `dir`         | The workspace directory to watch. **Commands execute automatically in this directory.** | `string`             |
 | `cmd`         | Defines the command(s) to be executed. Can be a string or an array. No `cd` prefix needed. | `string` \| `array`  |
-| `bin_path`    | Specifies the path to the binary to execute, invoked after `cmd`.    | `string`             |
+| `bin_path`    | Path to the binary to execute, **relative to the workspace directory**. E.g., `./target/debug/app` for Rust. | `string`             |
 | `bin_arg`     | Allows additional arguments for the binary to be provided.        | `array`              |
-| `ignore`      | Lists directories or files to be ignored.                        | `array`              |
+| `ignore`      | Lists directories or files to be ignored. Paths relative to workspace dir. | `array`              |
 | `env_file`    | Path to `.env` file for loading environment variables. Relative to workspace dir or absolute from root (prefix with `/`). | `string`             |
 

--- a/web/src/content/docs/usage/init.md
+++ b/web/src/content/docs/usage/init.md
@@ -1,0 +1,83 @@
+---
+title: Init Command
+sidebar:
+  order: 0
+---
+
+## Quick Start with Init
+
+The `rustywatch init` command creates a configuration file interactively, making it easy to get started with RustyWatch.
+
+### Basic Usage
+
+```shell
+rustywatch init
+```
+
+This launches an interactive wizard that:
+1. Detects your project type automatically
+2. Prompts for watch directory, build commands, and binary path
+3. Asks about ignore patterns
+4. Shows a preview of the configuration
+5. Writes the `rustywatch.yaml` file
+
+### Command Options
+
+| Flag | Description |
+|------|-------------|
+| `-o, --output <FILE>` | Config file path (default: `rustywatch.yaml`) |
+| `--yes` | Skip prompts and use auto-detected defaults |
+| `-f, --force` | Overwrite existing config file |
+
+### Auto-Detection
+
+RustyWatch automatically detects your project type and suggests appropriate defaults:
+
+| Project Type | Detection File | Default Command | Default Binary |
+|-------------|----------------|-----------------|----------------|
+| **Rust** | `Cargo.toml` | `cargo build` | `target/debug/{name}` |
+| **Go** | `go.mod` | `go build` | `./{name}` |
+| **Node.js** | `package.json` | `npm run dev` | - |
+| **Python** | `pyproject.toml`, `setup.py`, `requirements.txt` | `python main.py` | - |
+| **Bun** | `bun.lockb` | `bun run start` | - |
+
+### Examples
+
+**Interactive mode (recommended for first-time setup):**
+
+```shell
+rustywatch init
+```
+
+**Quick setup with auto-detected defaults:**
+
+```shell
+rustywatch init --yes
+```
+
+**Custom output path:**
+
+```shell
+rustywatch init -o .rustywatch.yaml
+```
+
+**Force overwrite existing config:**
+
+```shell
+rustywatch init --force
+```
+
+### Interactive Prompts
+
+When running `rustywatch init`, you'll be asked:
+
+1. **Watch Directory** - Which directory should RustyWatch monitor for changes?
+2. **Build Command** - What command should run when files change?
+3. **Binary Path** - Where is the compiled binary located? (for compiled languages)
+4. **Ignore Patterns** - Which files/directories should be ignored?
+
+After answering, you'll see a preview of the generated YAML configuration before it's written to disk.
+
+:::tip
+Use `--yes` flag for CI/CD pipelines or when you trust the auto-detected defaults.
+:::

--- a/web/src/content/docs/usage/usage-with-config.md
+++ b/web/src/content/docs/usage/usage-with-config.md
@@ -29,18 +29,18 @@ workspaces:
     cmd:
       - echo "Building go-project..."
       - go build
-    bin_path: 'examples/go-project/go-project'
+    bin_path: './go-project'  # relative to workspace dir
     env_file: '.env'
   - dir: 'examples/nodejs-project'
     cmd: npm start
-    env_file: '/.env'
+    env_file: '/.env'  # loads from project root
   - dir: 'examples/rust-project'
     cmd:
       - echo "Building rust-project..."
       - cargo build
-    bin_path: 'examples/rust-project/target/debug/rust-project'
+    bin_path: './target/debug/rust-project'  # relative to workspace dir
     ignore:
-      - 'examples/rust-project/target/'
+      - 'target/'
 ```
 
 :::tip
@@ -51,8 +51,8 @@ Commands automatically execute in the workspace `dir` directory. No need for `cd
 
 - `dir`: The project directory to watch. **Commands automatically execute in this directory.**
 - `cmd`: The commands to run for each project. Can be a single command or an array of commands.
-- `bin_path`: The path to the binary executable file produced after the build.
-- `ignore` (optional): Files or directories that should be excluded from being monitored by RustyWatch. For example, the Rust project's target directory is ignored to avoid unnecessary rebuilds.
+- `bin_path`: The path to the binary executable file, **relative to the workspace directory**. For example, in a Rust project with `dir: 'my-app'`, use `bin_path: './target/debug/my-app'` instead of `bin_path: 'my-app/target/debug/my-app'`.
+- `ignore` (optional): Files or directories that should be excluded from being monitored by RustyWatch. Paths are relative to the workspace directory.
 - `env_file` (optional): Path to a `.env` file containing environment variables. Use a relative path (e.g., `.env`) to load from the workspace directory, or prefix with `/` (e.g., `/.env`) to load from the project root.
 
 
@@ -62,7 +62,7 @@ Commands automatically execute in the workspace `dir` directory. No need for `cd
 
 - Located in `examples/go-project`
 - Commands: `go build` (runs in `examples/go-project/`)
-- Binary location: `examples/go-project/go-project`
+- Binary location: `./go-project` (relative to workspace dir)
 
 **Node.js Project:**
 
@@ -73,7 +73,7 @@ Commands automatically execute in the workspace `dir` directory. No need for `cd
 
 - Located in `examples/rust-project`
 - Commands: `cargo build` (runs in `examples/rust-project/`)
-- Binary location: `examples/rust-project/target/debug/rust-project`
+- Binary location: `./target/debug/rust-project` (relative to workspace dir)
 - The `target/` directory is ignored to prevent unnecessary rebuilds.
 
 **Usage**


### PR DESCRIPTION
- Update bin_path in config to be relative to workspace dir instead of project root
- Fix path resolution to properly join CWD + work_dir + bin_path
- Add check to skip restart if binary doesn't exist after build
- Fix typo in log message (Waching -> Watching)

<!--- Thank you for contributing to rustywatch! -->

## Description of change

<!-- Please write a summary of your changes and why you made them. -->
<!-- Be sure to reference any related issues by adding `Closes #`. -->

## How has this been tested? (if applicable)

<!-- Please describe any tests that you ran to verify your changes. -->
